### PR TITLE
Ignore off budget accounts from ynab

### DIFF
--- a/ynab_to_ledger.rb
+++ b/ynab_to_ledger.rb
@@ -25,6 +25,8 @@ def ledger_entry(row)
     source = row["Category Group/Category"]
   end
 
+  return if source == ""
+
   <<END
 #{year}/#{month}/#{day} #{row["Payee"]}#{row["Memo"]}
     #{source}             #{outflow}


### PR DESCRIPTION
Issue:  ynab allows for off budget accounts ([tracking accounts](http://docs.youneedabudget.com/article/177-account-types)). 

In the CSV export, they can look like this:

```csv
"Account","Flag","Date","Payee","Category Group/Category","Category Group","Category","Memo","Outflow","Inflow","Cleared"
"401k","","03/29/2016","Starting Balance","","","","",$0.00,$5,"Reconciled"
"401k","","04/19/2016","Reconciliation Balance Adjustment","","","","Entered automatically by YNAB",$0.00,$6,"Reconciled"
```

The generated dat produces:

```ledger
2016/03/29 Starting Balance
                 
    401k     $5

2016/04/19 Reconciliation Balance AdjustmentEntered automatically by YNAB
                 
    401k     $6
```

These are not valid ledger entries, and causes issues trying to parse them.  

This PR aims to ignore these tracking accounts by skipping the entry if the source is blank. 


